### PR TITLE
Fix incompatibility with OpenDKIM since Alpine 3.11 (#1)

### DIFF
--- a/Dockerfile.tmpl.php
+++ b/Dockerfile.tmpl.php
@@ -43,6 +43,9 @@ RUN apt-get update \
         libmilter \
         # Perl and LibreSSL required for opendkim-* utilities
         libressl perl \
+ # Add openssl symlink to libressl to fix incompatibility with OpenDKIM
+ # since Alpine 3.11
+ && ln -sf /usr/bin/libressl /usr/bin/openssl \
 <? } else { ?>
  && apt-get install -y --no-install-recommends --no-install-suggests \
             libssl1.0.0 \
@@ -115,10 +118,6 @@ RUN apt-get update \
     \
  # Install OpenDKIM
  && make install \
-<? if ($isAlpineImage) { ?>
- # Add symlink openssl to libressl to fix incompatibility with OpenDKIM since Alpine 3.11
- && ln -sf /usr/bin/libressl /usr/bin/openssl \
-<? } ?>
  # Prepare run directory
  && install -d -o opendkim -g opendkim /run/opendkim/ \
  # Preserve licenses

--- a/Dockerfile.tmpl.php
+++ b/Dockerfile.tmpl.php
@@ -115,6 +115,10 @@ RUN apt-get update \
     \
  # Install OpenDKIM
  && make install \
+<? if ($isAlpineImage) { ?>
+ # Add symlink openssl to libressl to fix incompatibility with OpenDKIM since Alpine 3.11
+ && ln -sf /usr/bin/libressl /usr/bin/openssl \
+<? } ?>
  # Prepare run directory
  && install -d -o opendkim -g opendkim /run/opendkim/ \
  # Preserve licenses

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -58,6 +58,8 @@ RUN apk update \
     \
  # Install OpenDKIM
  && make install \
+ # Add symlink openssl to libressl to fix incompatibility with OpenDKIM since Alpine 3.11
+ && ln -sf /usr/bin/libressl /usr/bin/openssl \
  # Prepare run directory
  && install -d -o opendkim -g opendkim /run/opendkim/ \
  # Preserve licenses

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -19,6 +19,9 @@ RUN apk update \
         libmilter \
         # Perl and LibreSSL required for opendkim-* utilities
         libressl perl \
+ # Add openssl symlink to libressl to fix incompatibility with OpenDKIM
+ # since Alpine 3.11
+ && ln -sf /usr/bin/libressl /usr/bin/openssl \
     \
  # Install tools for building
  && apk add --no-cache --virtual .tool-deps \
@@ -58,8 +61,6 @@ RUN apk update \
     \
  # Install OpenDKIM
  && make install \
- # Add symlink openssl to libressl to fix incompatibility with OpenDKIM since Alpine 3.11
- && ln -sf /usr/bin/libressl /usr/bin/openssl \
  # Prepare run directory
  && install -d -o opendkim -g opendkim /run/opendkim/ \
  # Preserve licenses

--- a/test/suite.bats
+++ b/test/suite.bats
@@ -49,7 +49,8 @@
 }
 
 @test "opendkim-genkey: runs ok" {
-  run docker run --rm --entrypoint sh $IMAGE -c 'opendkim-genkey --help'
+  run docker run --rm --entrypoint sh $IMAGE -c \
+    'opendkim-genkey && [ -f default.private ] && [ -f default.txt ]'
   [ "$status" -eq 0 ]
 }
 


### PR DESCRIPTION
Fixes #1 

FCM
```
Fix incompatibility with OpenDKIM since Alpine 3.11 (#3, #1)

- add symlink openssl to libressl
- update test for 'opendkim-genkey'
```