### PR TITLE
Build with "--with-lua" flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,15 @@ All user visible changes to this project will be documented in this file. This p
 
 [Diff](/../../compare/2.11.0-Beta2-r25...main)
 
+### Added
+
+- Support for processing mails [with a Lua script](http://www.opendkim.org/opendkim-lua.3.html) via `SetupPolicyScript` configuration parameter. ([#16])
+
 ### Security updated
 
 - [Debian Linux] "bookworm" 20250610 (12.11): <https://github.com/docker-library/official-images/commit/5b9d8958f88a1485f8edcaed4800fcfaac500b28>
+
+[#16]: /../../pull/16
 
 
 

--- a/Dockerfile.tmpl.php
+++ b/Dockerfile.tmpl.php
@@ -80,7 +80,7 @@ RUN apt-get update \
         libmilter-dev \
         libopendbx1-dev \
         libbsd-dev \
-        lua5.1-dev \
+        liblua5.1-0-dev \
     " \
  && apt-get install -y --no-install-recommends --no-install-suggests \
             $buildDeps \

--- a/Dockerfile.tmpl.php
+++ b/Dockerfile.tmpl.php
@@ -42,6 +42,7 @@ RUN apt-get update \
  && apk add --no-cache --force \
         libcrypto3 libssl3 \
         libmilter \
+        lua5.1-libs \
         opendbx \
         opendbx-backend-mysql opendbx-backend-postgres opendbx-backend-sqlite \
         # Perl and OpenSSL required for opendkim-* utilities
@@ -49,6 +50,7 @@ RUN apt-get update \
 <? } else { ?>
  && apt-get install -y --no-install-recommends --no-install-suggests \
             libssl3 \
+            liblua5.1-0 \
             libmilter1.0.1 \
             libopendbx1 \
             libopendbx1-mysql libopendbx1-pgsql libopendbx1-sqlite3 \

--- a/Dockerfile.tmpl.php
+++ b/Dockerfile.tmpl.php
@@ -73,12 +73,14 @@ RUN apt-get update \
         openssl-dev \
         libmilter-dev \
         opendbx-dev \
+        lua5.1-dev \
 <? } else { ?>
  && buildDeps=" \
         libssl-dev \
         libmilter-dev \
         libopendbx1-dev \
         libbsd-dev \
+        lua5.1-dev \
     " \
  && apt-get install -y --no-install-recommends --no-install-suggests \
             $buildDeps \
@@ -99,6 +101,7 @@ RUN apt-get update \
         --with-odbx \
         --with-openssl \
         --with-sql-backend \
+        --with-lua \
         # No documentation included to keep image size smaller
         --docdir=/tmp/opendkim/doc \
         --htmldir=/tmp/opendkim/html \

--- a/Dockerfile.tmpl.php
+++ b/Dockerfile.tmpl.php
@@ -98,10 +98,10 @@ RUN apt-get update \
     ./configure \
         --prefix=/usr \
         --sysconfdir=/etc/opendkim \
+        --with-lua \
         --with-odbx \
         --with-openssl \
         --with-sql-backend \
-        --with-lua \
         # No documentation included to keep image size smaller
         --docdir=/tmp/opendkim/doc \
         --htmldir=/tmp/opendkim/html \

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -37,6 +37,7 @@ RUN echo "@edge-community https://dl-cdn.alpinelinux.org/alpine/edge/community" 
         openssl-dev \
         libmilter-dev \
         opendbx-dev \
+        lua5.1-dev \
     \
  # Download and prepare OpenDKIM sources
  && curl -fL -o /tmp/opendkim.tar.gz \
@@ -50,6 +51,7 @@ RUN echo "@edge-community https://dl-cdn.alpinelinux.org/alpine/edge/community" 
     ./configure \
         --prefix=/usr \
         --sysconfdir=/etc/opendkim \
+        --with-lua \
         --with-odbx \
         --with-openssl \
         --with-sql-backend \

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -23,6 +23,7 @@ RUN echo "@edge-community https://dl-cdn.alpinelinux.org/alpine/edge/community" 
  && apk add --no-cache --force \
         libcrypto3 libssl3 \
         libmilter \
+        lua5.1-libs \
         opendbx \
         opendbx-backend-mysql opendbx-backend-postgres opendbx-backend-sqlite \
         # Perl and OpenSSL required for opendkim-* utilities

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update \
  # Install OpenDKIM dependencies
  && apt-get install -y --no-install-recommends --no-install-suggests \
             libssl3 \
+            liblua5.1-0 \
             libmilter1.0.1 \
             libopendbx1 \
             libopendbx1-mysql libopendbx1-pgsql libopendbx1-sqlite3 \

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
         libmilter-dev \
         libopendbx1-dev \
         libbsd-dev \
+        liblua5.1-0-dev \
     " \
  && apt-get install -y --no-install-recommends --no-install-suggests \
             $buildDeps \
@@ -53,6 +54,7 @@ RUN apt-get update \
     ./configure \
         --prefix=/usr \
         --sysconfdir=/etc/opendkim \
+        --with-lua \
         --with-odbx \
         --with-openssl \
         --with-sql-backend \

--- a/tests/main.bats
+++ b/tests/main.bats
@@ -34,6 +34,12 @@
   [ "$status" -eq 0 ]
 }
 
+@test "opendkim: Lua supported" {
+  run docker run --rm --pull never --entrypoint sh $IMAGE -c \
+    'opendkim -V | grep -F USE_LUA'
+  [ "$status" -eq 0 ]
+}
+
 
 @test "opendkim-genkey: runs ok" {
   run docker run --rm --pull never --entrypoint sh $IMAGE -c \


### PR DESCRIPTION
Add support for processing mails [with a lua script](http://www.opendkim.org/opendkim-lua.3.html) via the [`SetupPolicyScript`](https://www.opendkim.org/opendkim.conf.5.html) configuration parameter.

Requires the dependency for `lua5.1-dev` (could be higher, but tested it with 5.1) so that opendkim can be build with [`--with-lua`](http://www.opendkim.org/INSTALL).

Tested locally with both debian and alpine packages on the :latest tag.